### PR TITLE
Don't add executable dependencies to link ones

### DIFF
--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -200,6 +200,9 @@ class ProjectGenerator
 
 			buildsettings.add(depbs);
 
+			if (depbs.targetType == TargetType.executable)
+				continue;
+
 			auto pt = (generates_binary ? pack.name : bin_pack) in targets;
 			assert(pt !is null);
 			if (auto pdt = depname in targets) {


### PR DESCRIPTION
At some point executable dependencies will need dedicated "pathDependency"
support. For now those better be ignored - no one is going to link against
an executable.

Without this fix adding dependency with `targetType : executable` resulted
in broken DFLAGS generated because binary name from dependency was added to
the linker flags as if it was a static library.