### PR TITLE
Dub no longer defaults to available compiler

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -20,7 +20,6 @@ import dub.packagesupplier;
 import dub.platform : determineCompiler;
 import dub.project;
 import dub.internal.utils : getDUBVersion, getClosestMatch;
-import dub.version_;
 
 import std.algorithm;
 import std.array;
@@ -357,7 +356,7 @@ abstract class PackageBuildCommand : Command {
 		string m_buildType;
 		BuildMode m_buildMode;
 		string m_buildConfig;
-		string m_compilerName = initialCompilerBinary;
+		string m_compilerName;
 		string m_arch;
 		string[] m_debugVersions;
 		Compiler m_compiler;
@@ -366,6 +365,11 @@ abstract class PackageBuildCommand : Command {
 		string m_defaultConfig;
 		bool m_nodeps;
 		bool m_forceRemove = false;
+	}
+
+	this()
+	{
+		m_compilerName = defaultCompiler();
 	}
 
 	override void prepare(scope CommandArgs args)
@@ -382,7 +386,7 @@ abstract class PackageBuildCommand : Command {
 			"Specifies the compiler binary to use (can be a path).",
 			"Arbitrary pre- and suffixes to the identifiers below are recognized (e.g. ldc2 or dmd-2.063) and matched to the proper compiler type:",
 			"  "~["dmd", "gdc", "ldc", "gdmd", "ldmd"].join(", "),
-			"Default value: "~initialCompilerBinary,
+			"Default value: "~m_compilerName,
 		]);
 		args.getopt("a|arch", &m_arch, [
 			"Force a different architecture (e.g. x86 or x86_64)"


### PR DESCRIPTION
I'm on Archlinux with `dmd` as my only D compiler. I just updated to dub `0.9.22-2` (from `0.9.22-1`), and now running `dub build` reports `/bin/bash: ldc: command not found`. Using `dub --compiler=dmd` works, but this was unnecessary before the update.
 Is dub supposed to default to an available compiler? 
Or was it just defaulting to `dmd` before and I didn't notice because I only used `dmd`?
