### PR TITLE
escaping local static array

### DIFF
--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -603,9 +603,9 @@ class PackageManager {
 				logDebug("Hashed file contents from %s", Path(file.name).head);
 			}
 		}
-		auto hash = sha1.finish();
+		auto hash = sha1.finish().dup;
 		logDebug("Project hash: %s", hash);
-		return hash[0..$];
+		return hash;
 	}
 
 	private void writeLocalPackageList(LocalPackageType type)


### PR DESCRIPTION
SHA1.finish returns a static array. In git head, dmd rejects escaping local static array.
PackageManager.hashPackage is used nowhere in dub though.

```
source/dub/packagemanager.d(608): Error: escaping reference to local variable hash
```