### PR TITLE
dub build --build=ddox doesn't work on OS X

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -678,7 +678,7 @@ class Dub {
 		if (!run) {
 			commands ~= dub_path~"ddox generate-html --navigation-type=ModuleTree docs.json docs";
 			version(Windows) commands ~= "xcopy /S /D "~dub_path~"public\\* docs\\";
-			else commands ~= "cp -ru \""~dub_path~"public\"/* docs/";
+			else commands ~= "rsync -ru '"~dub_path~"public/' docs/";
 		}
 		runCommands(commands);
 


### PR DESCRIPTION
Seems like OSX's version of `cp` doesn't support `u` option.

```
% dub build --build=ddox --vverbose

Using dub registry url 'http://code.dlang.org/'
Looking for local package map at /var/lib/dub/packages/local-packages.json
Looking for local package map at /Users/pavel/.dub/packages/local-packages.json
iterating dir /Users/pavel/.dub/packages/
iterating dir /Users/pavel/.dub/packages/ entry ddox-0.9.22
iterating dir /Users/pavel/.dub/packages/ entry dyaml-master
iterating dir /Users/pavel/.dub/packages/ entry libev-master
iterating dir /Users/pavel/.dub/packages/ entry libevent-master
iterating dir /Users/pavel/.dub/packages/ entry openssl-master
iterating dir /Users/pavel/.dub/packages/ entry vibe-d-0.7.20
Looking for local package map at /var/lib/dub/packages/local-packages.json
Looking for local package map at /Users/pavel/.dub/packages/local-packages.json
iterating dir /Users/pavel/.dub/packages/
iterating dir /Users/pavel/.dub/packages/ entry ddox-0.9.22
iterating dir /Users/pavel/.dub/packages/ entry dyaml-master
iterating dir /Users/pavel/.dub/packages/ entry libev-master
iterating dir /Users/pavel/.dub/packages/ entry libevent-master
iterating dir /Users/pavel/.dub/packages/ entry openssl-master
iterating dir /Users/pavel/.dub/packages/ entry vibe-d-0.7.20
Determined package version using GIT: mysql-d ~master
Looking for local package map at /var/lib/dub/packages/local-packages.json
Looking for local package map at /Users/pavel/.dub/packages/local-packages.json
iterating dir /Users/pavel/.dub/packages/
iterating dir /Users/pavel/.dub/packages/ entry ddox-0.9.22
iterating dir /Users/pavel/.dub/packages/ entry dyaml-master
iterating dir /Users/pavel/.dub/packages/ entry libev-master
iterating dir /Users/pavel/.dub/packages/ entry libevent-master
iterating dir /Users/pavel/.dub/packages/ entry openssl-master
iterating dir /Users/pavel/.dub/packages/ entry vibe-d-0.7.20
Looking for local package map at /var/lib/dub/packages/local-packages.json
Looking for local package map at /Users/pavel/.dub/packages/local-packages.json
iterating dir /Users/pavel/.dub/packages/
iterating dir /Users/pavel/.dub/packages/ entry ddox-0.9.22
iterating dir /Users/pavel/.dub/packages/ entry dyaml-master
iterating dir /Users/pavel/.dub/packages/ entry libev-master
iterating dir /Users/pavel/.dub/packages/ entry libevent-master
iterating dir /Users/pavel/.dub/packages/ entry openssl-master
iterating dir /Users/pavel/.dub/packages/ entry vibe-d-0.7.20
Collecting dependencies for mysql-d
Checking dependencies in '/Users/pavel/Sites/mysql-d'
Add config mysql-d library
Using configuration 'library' for mysql-d
Generating using build
Creating build generator.
Add config mysql-d library
Using configuration 'library' for mysql-d
Fixing relative path: /Users/pavel/Sites/mysql-d ~ source/mysql/d.d
Fixing relative path: /Users/pavel/Sites/mysql-d ~ source/mysql/database.d
Fixing relative path: /Users/pavel/Sites/mysql-d ~ source/mysql/mysql.d
Fixing relative path: /Users/pavel/Sites/mysql-d ~ source/
Fixing relative path: /Users/pavel/Sites/mysql-d ~ .
Fixing relative path: /Users/pavel/Sites/mysql-d ~ .
Generate target mysql-d (staticLibrary /Users/pavel/Sites/mysql-d mysql-d)
mysql-d: ["mysql-d"]
Building configuration "library", build type ddox
Ignoring all import libraries for static library build.
Trying to use pkg-config to resolve library flags for [].
pkg-config failed: pkg-config exited with error code 1
Falling back to direct -lxyz flags.
Running dmd...
dmd -c -Df__dummy.html -Xfdocs.json -o- -w -version=MySQL_51 -version=Have_mysql_d -Isource source/mysql/d.d source/mysql/database.d source/mysql/mysql.d
Running /Users/pavel/.dub/packages/ddox-0.9.22/ddox filter --min-protection=Protected --only-documented docs.json
Reading doc file...
Parsing JSON...
Filtering modules...
Writing filtered docs...
Running /Users/pavel/.dub/packages/ddox-0.9.22/ddox generate-html --navigation-type=ModuleTree docs.json docs
Reading doc file...
Parsing JSON...
Parsing docs...
Finished parsing docs.
Generating module: mysql.mysql
Running cp -ru "/Users/pavel/.dub/packages/ddox-0.9.22/public"/* docs/
cp: illegal option -- u
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file ... target_directory
Error executing command build: Command failed with exit code 64
```