### PR TITLE
Fixed singleFile build mode issues

### DIFF
--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -185,7 +185,8 @@ enum TargetType {
 	library,
 	sourceLibrary,
 	dynamicLibrary,
-	staticLibrary
+	staticLibrary,
+	object
 }
 
 enum BuildRequirements {

--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -366,6 +366,10 @@ string getTargetFileName(in BuildSettings settings, in BuildPlatform platform)
 			if( platform.platform.canFind("windows") )
 				return settings.targetName ~ ".dll";
 			else return "lib" ~ settings.targetName ~ ".so";
+		case TargetType.object:
+			if (platform.platform.canFind("windows"))
+				return settings.targetName ~ ".obj";
+			else return settings.targetName ~ ".o";
 	}
 }
 

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -169,6 +169,9 @@ class DmdCompiler : Compiler {
 				version (Windows) settings.addDFlags("-shared");
 				else settings.addDFlags("-shared", "-fPIC");
 				break;
+			case TargetType.object:
+				settings.addDFlags("-c");
+				break;
 		}
 
 		if (tpath is null)

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -167,6 +167,7 @@ class GdcCompiler : Compiler {
 			case TargetType.executable: break;
 			case TargetType.library:
 			case TargetType.staticLibrary:
+			case TargetType.object:
 				settings.addDFlags("-c");
 				break;
 			case TargetType.dynamicLibrary:

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -157,6 +157,9 @@ class LdcCompiler : Compiler {
 			case TargetType.dynamicLibrary:
 				settings.addDFlags("-shared");
 				break;
+			case TargetType.object:
+				settings.addDFlags("-c");
+				break;
 		}
 
 		if (tpath is null)

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -362,8 +362,8 @@ class BuildGenerator : ProjectGenerator {
 		string objPath = tempobj.toNativeString();
 		bs.libs = null;
 		bs.lflags = null;
-		bs.addDFlags("-c");
 		bs.sourceFiles = [ srcFile ];
+		bs.targetType = TargetType.object;
 		gs.compiler.prepareBuildSettings(bs, BuildSetting.commandLine);
 		gs.compiler.setTarget(bs, gs.platform, objPath);
 		gs.compiler.invoke(bs, gs.platform, gs.compileCallback);

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -350,7 +350,12 @@ class BuildGenerator : ProjectGenerator {
 	/// Output an unique name to represent the source file.
 	/// Calls with path that resolve to the same file on the filesystem will return the same,
 	/// unless they include different symbolic links (which are not resolved).
-	static string pathToObjName(string path) { return std.path.buildNormalizedPath(getcwd(), path~objSuffix)[1..$].replace("/", "."); }
+
+	static string pathToObjName(string path)
+	{
+		return std.path.stripDrive(std.path.buildNormalizedPath(getcwd(), path~objSuffix))[1..$].replace(std.path.dirSeparator, ".");
+	}
+
 	/// Compile a single source file (srcFile), and write the object to objName.
 	static string compileUnit(string srcFile, string objName, BuildSettings bs, GeneratorSettings gs) {
 		Path tempobj = Path(bs.targetPath)~objName;


### PR DESCRIPTION
+ Fixed error with long command line when invoking the linker on Windows
+ Fixed issue where singleFile build mode builds each file as a static library instead of as an object file
+ Fixed object file naming on Windows