### PR TITLE
Fix: dub broken if compiled with absolute path DC

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -59,6 +59,10 @@ private string findCompiler()
 	version (Windows) enum sep = ";", exe = ".exe";
 	version (Posix) enum sep = ":", exe = "";
 
+	// if it is absolute path -> works without prefixes
+	if (existsFile(initialCompilerBinary))
+		return initialCompilerBinary;
+
 	auto paths = env.get("PATH", "").splitter(sep).map!Path;
 	auto res = [initialCompilerBinary, "dmd", "gdc", "gdmd", "ldc2", "ldmd2"]
 		.find!(bin => paths.canFind!(p => existsFile(p ~ (bin~exe))));


### PR DESCRIPTION
More broken things found by my test suite ;)

Code that was supposed to find working compiler always tried to
build absolute path from compiler name - even it was absolute
path already.