### PR TITLE
Persistent Object Caching

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -353,11 +353,16 @@ class BuildGenerator : ProjectGenerator {
 	static string pathToObjName(string path) { return std.path.buildNormalizedPath(getcwd(), path~objSuffix)[1..$].replace("/", "."); }
 	/// Compile a single source file (srcFile), and write the object to objName.
 	static string compileUnit(string srcFile, string objName, BuildSettings bs, GeneratorSettings gs) {
+            import std.stdio;
+            writeln("srcFile: ", srcFile);
+            writeln("objName: ", objName);
 		Path tempobj = Path(bs.targetPath)~objName;
 		string objPath = tempobj.toNativeString();
+                writeln("objPath: ", objPath);
 		bs.libs = null;
 		bs.lflags = null;
 		bs.addDFlags("-c");
+		bs.addDFlags("-deps");
 		bs.sourceFiles = [ srcFile ];
 		gs.compiler.prepareBuildSettings(bs, BuildSetting.commandLine);
 		gs.compiler.setTarget(bs, gs.platform, objPath);


### PR DESCRIPTION
This PR aims to implement robust caching of generated objects by adding logic that checks whether all sources files, compiler exectuables, etc an object depends upon are newer than the previously generated object file itself.

The logic will be activated only when the argument `--build-mode=singleFile` is fed to `dub`.

So far I've only added `-deps` flag to the compiler. Now I need guidance on

- where and how to parse the compiler output lines outputted by the `-deps` flag lines (lines beginning with `dep`).
- where to persistently save and load the associative array mapping source files to their previously scanned dependencies.

When this is done. I suggest to add logic in `BuildGenerator.compileUnit` that checks whether srcFile and all its dependencies are newer than the objPath (if it exists). 

A typical value for `objPath` is

`dub/build/application-debug-linux.posix-x86_64-dmd_2067-5C25CF5E0907389BD865D47A5E97D174/home.per.Work.justd.module_name.d.o`

I'm guessing this is a MD5-digest (32 hex digits, 16 bytes).
Should this digest be reused in a hash-chain used as keys in the persistent cache?