### PR TITLE
Fix misplaced closing bracket.

### DIFF
--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -264,8 +264,8 @@ interface Compiler {
 		}
 
 		version (Posix) if (status == -9) {
-			throw new Exception(format("%s failed with exit code %s. This may indicate that the process has run out of memory."),
-				args[0], status);
+			throw new Exception(format("%s failed with exit code %s. This may indicate that the process has run out of memory.",
+				args[0], status));
 		}
 		enforce(status == 0, format("%s failed with exit code %s.", args[0], status));
 	}


### PR DESCRIPTION
This fixes the following error:
```
Error executing command build: Orphan format specifier: %%s failed with exit code %s. This may indicate that the process has run out of memory.
Full exception: std.format.FormatException@/usr/include/dmd/phobos/std/format.d(440): Orphan format specifier: %%s failed with exit code %s. This may indicate that the process has run out of memory.
```