### PR TITLE
Pass 'x86-64' arch to LDC instead of 'x86_64'

### DIFF
--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -68,7 +68,7 @@ class LdcCompiler : Compiler {
 				break;
 			case "x86_64":
 				build_platform.architecture = ["x86_64"];
-				settings.addDFlags("-march=x86_64");
+				settings.addDFlags("-march=x86-64");
 				break;
 		}
 


### PR DESCRIPTION
This fixes https://github.com/D-Programming-Language/dub/issues/573 here.