### PR TITLE
Fix #393: 'dub describe' now adds an 'active' field to each dependency

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -810,7 +810,17 @@ class DescribeCommand : PackageBuildCommand {
 		} else if (m_stringImportPaths) {
 			dub.listStringImportPaths(m_buildPlatform, config);
 		} else {
-			dub.describeProject(m_buildPlatform, config);
+
+			GeneratorSettings gensettings;
+			gensettings.platform = m_buildPlatform;
+			gensettings.config = m_buildConfig.length ? m_buildConfig : m_defaultConfig;
+			gensettings.buildType = m_buildType;
+			gensettings.buildMode = m_buildMode;
+			gensettings.compiler = m_compiler;
+			gensettings.buildSettings = m_buildSettings;
+			gensettings.runArgs = app_args;
+
+			dub.describeProject(m_buildPlatform, config, gensettings);
 		}
 
 		return 0;
@@ -1670,4 +1680,3 @@ private void warnRenamed(string prev, string curr)
 {
 	logWarn("The '%s' Command was renamed to '%s'. Please update your scripts.", prev, curr);
 }
-

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -414,7 +414,7 @@ class Dub {
 	}
 
 	/// Outputs a JSON description of the project, including its dependencies.
-	void describeProject(BuildPlatform platform, string config)
+	void describeProject(BuildPlatform platform, string config, GeneratorSettings gensettings)
 	{
 		auto dst = Json.emptyObject;
 		dst.configuration = config;
@@ -422,7 +422,7 @@ class Dub {
 		dst.architecture = platform.architecture.serializeToJson();
 		dst.platform = platform.platform.serializeToJson();
 
-		m_project.describe(dst, platform, config);
+		m_project.describe(dst, platform, config, gensettings);
 
 		import std.stdio;
 		write(dst.toPrettyString());
@@ -1057,4 +1057,3 @@ class DependencyVersionResolver : DependencyResolver!(Dependency, Dependency) {
 		return null;
 	}
 }
-


### PR DESCRIPTION
I reckon the codebase still has some refactoring to do; I tried to keep the patch as simple as possible to implement the desired behaviour. I tested the patch by actually using the output of `dub describe` and it seems to work like a treat.