### PR TITLE
Fix compilation failure on DMD/Phobos master

### DIFF
--- a/source/dub/generators/generator.d
+++ b/source/dub/generators/generator.d
@@ -420,7 +420,7 @@ private void finalizeGeneration(string pack, in BuildSettings buildsettings, Pat
 				{
 					foreach (glob; globs)
 					{
-						if (f.globMatch(glob))
+						if (f.name().globMatch(glob))
 						{
 							if (f.isDir)
 								tryCopyDir(f);


### PR DESCRIPTION
Because of range-ification of some Phobos functions
implicit convertion of DirEntry to string does not
work anymore.

Looks like this won't be considered regression, thus submitting the fixup.