### PR TITLE
Bugfix for #601. Inplace assignment of 'p = p.relativeTo(cwd)' was

### DIFF
--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -97,18 +97,12 @@ class BuildGenerator : ProjectGenerator {
 
 		// make all paths relative to shrink the command line
 		string makeRelative(string path) { 
-			auto p = Path(path); 
-			Path ret = null;
-			if (p.absolute) 
-			{
-				ret = p.relativeTo(cwd); 
-			}
-			else
-			{
-				ret = p;
-			}
-			return ret.toNativeString(); 
+			auto orig = Path(path); Path rel = null;
+			rel = (orig.absolute ? orig.relativeTo(cwd) 
+			                     : orig);
+			return rel.toNativeString(); 
 		}
+
 		foreach (ref f; buildsettings.sourceFiles) f = makeRelative(f);
 		foreach (ref p; buildsettings.importPaths) p = makeRelative(p);
 		foreach (ref p; buildsettings.stringImportPaths) p = makeRelative(p);

--- a/source/dub/generators/build.d
+++ b/source/dub/generators/build.d
@@ -96,7 +96,19 @@ class BuildGenerator : ProjectGenerator {
 		auto build_id = computeBuildID(config, buildsettings, settings);
 
 		// make all paths relative to shrink the command line
-		string makeRelative(string path) { auto p = Path(path); if (p.absolute) p = p.relativeTo(cwd); return p.toNativeString(); }
+		string makeRelative(string path) { 
+			auto p = Path(path); 
+			Path ret = null;
+			if (p.absolute) 
+			{
+				ret = p.relativeTo(cwd); 
+			}
+			else
+			{
+				ret = p;
+			}
+			return ret.toNativeString(); 
+		}
 		foreach (ref f; buildsettings.sourceFiles) f = makeRelative(f);
 		foreach (ref p; buildsettings.importPaths) p = makeRelative(p);
 		foreach (ref p; buildsettings.stringImportPaths) p = makeRelative(p);

--- a/source/dub/internal/vibecompat/inet/path.d
+++ b/source/dub/internal/vibecompat/inet/path.d
@@ -34,7 +34,7 @@ struct Path {
 	/// Constructs a Path object by parsing a path string.
 	this(string pathstr)
 	{
-		m_nodes = cast(immutable)splitPath(pathstr);
+		m_nodes = (splitPath(pathstr).idup);
 		m_absolute = (pathstr.startsWith("/") || m_nodes.length > 0 && (m_nodes[0].toString().countUntil(':')>0 || m_nodes[0] == "\\"));
 		m_endsWithSlash = pathstr.endsWith("/");
 	}
@@ -283,7 +283,7 @@ struct PathEntry {
 
 	string toString() const { return m_name; }
 
-	Path opBinary(string OP)(PathEntry rhs) const if( OP == "~" ) { return Path(cast(immutable)[this, rhs], false); }
+	Path opBinary(string OP)(PathEntry rhs) const if( OP == "~" ) { return Path(([this, rhs]).idup, false); }
 
 	bool opEquals(ref const PathEntry rhs) const { return m_name == rhs.m_name; }
 	bool opEquals(PathEntry rhs) const { return m_name == rhs.m_name; }


### PR DESCRIPTION
 causing memory corruption, probably due to reallocations. 
Using a second variable to hold the result of the operation as a fix.

Was a little hard to catch because of the single-line function.  I spread the operations out to help with the debugging.