### PR TITLE
Avoids duplicate dflags when calling BuildSettings.add. This avoid de…

### DIFF
--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -62,7 +62,7 @@ struct BuildSettings {
 
 	void add(in BuildSettings bs)
 	{
-		addDFlags(bs.dflags);
+		addDFlagsNoDuplicates(bs.dflags);
 		addLFlags(bs.lflags);
 		addLibs(bs.libs);
 		addLinkerFiles(bs.linkerFiles);
@@ -81,6 +81,7 @@ struct BuildSettings {
 	}
 
 	void addDFlags(in string[] value...) { dflags ~= value; }
+	void addDFlagsNoDuplicates(in string[] value...) { add(dflags, value); }
 	void removeDFlags(in string[] value...) { remove(dflags, value); }
 	void addLFlags(in string[] value...) { lflags ~= value; }
 	void addLibs(in string[] value...) { add(libs, value); }

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -171,7 +171,10 @@ class DmdCompiler : Compiler {
 				settings.addDFlags("-lib");
 				break;
 			case TargetType.dynamicLibrary:
-				settings.addDFlags("-shared");
+				version(linux)
+					settings.addDFlags("-shared", "-defaultlib=libphobos2.so");
+				else
+					settings.addDFlags("-shared");
 				break;
 			case TargetType.object:
 				settings.addDFlags("-c");

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -171,8 +171,7 @@ class DmdCompiler : Compiler {
 				settings.addDFlags("-lib");
 				break;
 			case TargetType.dynamicLibrary:
-				version (Windows) settings.addDFlags("-shared");
-				else settings.addDFlags("-shared", "-defaultlib=libphobos2.so");
+				settings.addDFlags("-shared");
 				break;
 			case TargetType.object:
 				settings.addDFlags("-c");

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -33,7 +33,7 @@ class LdcCompiler : Compiler {
 		//tuple(BuildOption.alwaysStackFrame, ["-?"]),
 		//tuple(BuildOption.stackStomping, ["-?"]),
 		tuple(BuildOption.inline, ["-enable-inlining"]),
-		tuple(BuildOption.noBoundsCheck, ["-disable-boundscheck"]),
+		tuple(BuildOption.noBoundsCheck, ["-boundscheck=off"]),
 		tuple(BuildOption.optimize, ["-O"]),
 		//tuple(BuildOption.profile, ["-?"]),
 		tuple(BuildOption.unittests, ["-unittest"]),

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -158,7 +158,10 @@ class LdcCompiler : Compiler {
 				settings.addDFlags("-lib");
 				break;
 			case TargetType.dynamicLibrary:
-				settings.addDFlags("-shared");
+				version(linux)
+					settings.addDFlags("-shared", "-defaultlib=phobos2");
+				else
+					settings.addDFlags("-shared");
 				break;
 			case TargetType.object:
 				settings.addDFlags("-c");

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -158,7 +158,7 @@ class LdcCompiler : Compiler {
 				settings.addDFlags("-lib");
 				break;
 			case TargetType.dynamicLibrary:
-				settings.addDFlags("-shared", "-defaultlib=phobos2");
+				settings.addDFlags("-shared");
 				break;
 			case TargetType.object:
 				settings.addDFlags("-c");


### PR DESCRIPTION
…pendent targets from getting architecture flags from dependencies when they already have them.