### PR TITLE
avoid early allocation and formatting of lazy message

### DIFF
--- a/source/dub/internal/vibecompat/data/json.d
+++ b/source/dub/internal/vibecompat/data/json.d
@@ -2110,7 +2110,7 @@ private void enforceJson(string file = __FILE__, size_t line = __LINE__)(bool co
 
 private void enforceJson(string file = __FILE__, size_t line = __LINE__)(bool cond, lazy string message, string err_file, int err_line)
 {
-	auto errmsg = format("%s(%s): Error: %s", err_file, err_line+1, message);
+	auto errmsg() { return format("%s(%s): Error: %s", err_file, err_line+1, message); }
 	static if (__VERSION__ >= 2065) enforceEx!JSONException(cond, errmsg, file, line);
 	else if (!cond) throw new JSONException(errmsg);
 }


### PR DESCRIPTION
- one of the biggest unneeded allocation sources in
  dub found while testing -profile=gc