### PR TITLE
add buildType profile=gc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ v0.9.24 - 2015-07-
  - Added a warning when referencing sub packages by their path (instead of their parent's path)
  - Building `sourceLibrary` targets with `-o-` is allowed now (enables documentation generation in particular) - [issue #553][issue553]
  - The VisualD generator doesn't use a "_d" suffix for debug build targets anymore (by Guillaume Piolat aka p0nce) - [pull #617][issue617]
+ - Added a new "profile-gc" build type
 
 ### Bug fixes ###
 

--- a/source/dub/compilers/buildsettings.d
+++ b/source/dub/compilers/buildsettings.d
@@ -289,6 +289,7 @@ enum BuildOption {
 	deprecationWarnings = 1<<18,  /// Warn about using deprecated features (-dw)
 	deprecationErrors = 1<<19,    /// Stop compilation upon usage of deprecated features (-de)
 	property = 1<<20,             /// DEPRECATED: Enforce property syntax (-property)
+	profileGC = 1<<21,            /// Profile runtime allocations
 }
 
 	struct BuildOptions {

--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -46,6 +46,7 @@ class DmdCompiler : Compiler {
 		tuple(BuildOption.deprecationWarnings, ["-dw"]),
 		tuple(BuildOption.deprecationErrors, ["-de"]),
 		tuple(BuildOption.property, ["-property"]),
+		tuple(BuildOption.profileGC, ["-profile=gc"]),
 	];
 
 	@property string name() const { return "dmd"; }

--- a/source/dub/compilers/gdc.d
+++ b/source/dub/compilers/gdc.d
@@ -46,6 +46,7 @@ class GdcCompiler : Compiler {
 		tuple(BuildOption.deprecationWarnings, ["-Wdeprecated"]),
 		tuple(BuildOption.deprecationErrors, ["-Werror", "-Wdeprecated"]),
 		tuple(BuildOption.property, ["-fproperty"]),
+		//tuple(BuildOption.profileGC, ["-?"]),
 	];
 
 	@property string name() const { return "gdc"; }

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -46,6 +46,7 @@ class LdcCompiler : Compiler {
 		tuple(BuildOption.deprecationWarnings, ["-dw"]),
 		tuple(BuildOption.deprecationErrors, ["-de"]),
 		tuple(BuildOption.property, ["-property"]),
+		//tuple(BuildOption.profileGC, ["-?"]),
 	];
 
 	@property string name() const { return "ldc"; }

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -302,6 +302,7 @@ class Package {
 				case "docs": settings.addOptions(syntaxOnly); settings.addDFlags("-c", "-Dddocs"); break;
 				case "ddox": settings.addOptions(syntaxOnly); settings.addDFlags("-c", "-Df__dummy.html", "-Xfdocs.json"); break;
 				case "profile": settings.addOptions(profile, optimize, inline, debugInfo); break;
+				case "profile-gc": settings.addOptions(profileGC, debugInfo); break;
 				case "cov": settings.addOptions(coverage, debugInfo); break;
 				case "unittest-cov": settings.addOptions(unittests, coverage, debugMode, debugInfo); break;
 			}


### PR DESCRIPTION
- allows to dub build -b profile=gc to trace memory allocations