### PR TITLE
The default compiler should not depend on DUB's own build environment

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -5,7 +5,6 @@
 @for /f %%i in ('git describe') do @set GITVER=%%i
 @echo module dub.version_; > source\dub\version_.d
 @echo enum dubVersion = "%GITVER%"; >> source\dub\version_.d
-@echo enum initialCompilerBinary = "%DC%"; >> source\dub\version_.d
 
 @echo Executing %DC%...
 @%DC% -ofbin\dub.exe -g -debug -w -version=DubUseCurl -Isource curl.lib %* @build-files.txt

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,6 @@ echo Generating version file...
 GITVER=$(git describe) || GITVER=unknown
 echo "module dub.version_;" > source/dub/version_.d
 echo "enum dubVersion = \"$GITVER\";" >> source/dub/version_.d
-echo "enum initialCompilerBinary = \"$DMD\";" >> source/dub/version_.d
 
 
 echo Running $DMD...

--- a/source/dub/compilers/compiler.d
+++ b/source/dub/compilers/compiler.d
@@ -55,21 +55,14 @@ string defaultCompiler()
 private string findCompiler()
 {
 	import std.process : env=environment;
-	import dub.version_ : initialCompilerBinary;
 	version (Windows) enum sep = ";", exe = ".exe";
 	version (Posix) enum sep = ":", exe = "";
 
-	auto def = Path(initialCompilerBinary);
-	if (def.absolute && existsFile(def))
-		return initialCompilerBinary;
-
 	auto compilers = ["dmd", "gdc", "gdmd", "ldc2", "ldmd2"];
-	if (!def.absolute)
-		compilers = initialCompilerBinary ~ compilers;
 
 	auto paths = env.get("PATH", "").splitter(sep).map!Path;
 	auto res = compilers.find!(bin => paths.canFind!(p => existsFile(p ~ (bin~exe))));
-	return res.empty ? initialCompilerBinary : res.front;
+	return res.empty ? compilers[0] : res.front;
 }
 
 void registerCompiler(Compiler c)
@@ -312,7 +305,7 @@ struct BuildPlatform {
 	bool matchesSpecification(const(char)[] specification)
 	const {
 		import std.string : format;
-		
+
 		if (specification.empty) return true;
 		if (this == any) return true;
 

--- a/source/dub/version_.d
+++ b/source/dub/version_.d
@@ -1,3 +1,2 @@
 module dub.version_; 
 enum dubVersion = "v0.9.23"; 
-enum initialCompilerBinary = "dmd"; 


### PR DESCRIPTION
When building DUB with `DMD=ldmd2 ./build.sh`, the resulting `dub` binary uses `ldmd2` as default compiler at runtime. But IMO the behaviour of `dub` at runtime should not depend on the environment it was built in.