### PR TITLE
Implement a commit hash based cache of local package versions.

### DIFF
--- a/source/dub/internal/utils.d
+++ b/source/dub/internal/utils.d
@@ -93,6 +93,22 @@ void writeJsonFile(Path path, Json json)
 	f.writePrettyJsonString(json);
 }
 
+/// Performs a write->delete->rename sequence to atomically "overwrite" the destination file
+void atomicWriteJsonFile(Path path, Json json)
+{
+	import std.random : uniform;
+	auto tmppath = path[0 .. $-1] ~ format("%s.%s.tmp", path.head, uniform(0, int.max));
+	auto f = openFile(tmppath, FileMode.createTrunc);
+	scope (failure) {
+		f.close();
+		removeFile(tmppath);
+	}
+	f.writePrettyJsonString(json);
+	f.close();
+	if (existsFile(path)) removeFile(path);
+	moveFile(tmppath, path);
+}
+
 bool isPathFromZip(string p) {
 	enforce(p.length > 0);
 	return p[$-1] == '/';

--- a/source/dub/package_.d
+++ b/source/dub/package_.d
@@ -598,38 +598,45 @@ class Package {
 
 private string determineVersionFromSCM(Path path)
 {
-	import std.file : exists, readText;
+	// On Windows, which is slow at running external processes,
+	// cache the version numbers that are determined using
+	// GIT to speed up the initialization phase.
+	version (Windows) {
+		import std.file : exists, readText;
 
-	// quickly determine head commit without invoking GIT
-	string head_commit;
-	auto hpath = (path ~ ".git/HEAD").toNativeString();
-	if (exists(hpath)) {
-		auto head_ref = readText(hpath).strip();
-		if (head_ref.startsWith("ref: ")) {
-			auto rpath = (path ~ (".git/"~head_ref[5 .. $])).toNativeString();
-			if (exists(rpath))
-				head_commit = readText(rpath).strip();
+		// quickly determine head commit without invoking GIT
+		string head_commit;
+		auto hpath = (path ~ ".git/HEAD").toNativeString();
+		if (exists(hpath)) {
+			auto head_ref = readText(hpath).strip();
+			if (head_ref.startsWith("ref: ")) {
+				auto rpath = (path ~ (".git/"~head_ref[5 .. $])).toNativeString();
+				if (exists(rpath))
+					head_commit = readText(rpath).strip();
+			}
 		}
-	}
 
-	// return the last determined version for that commit
-	// not that this is not always correct, most notably when
-	// a tag gets added/removed/changed and changes the outcome
-	// of the full version detection computation
-	auto vcachepath = path ~ ".dub/version.json";
-	if (existsFile(vcachepath)) {
-		auto ver = jsonFromFile(vcachepath);
-		if (head_commit == ver["commit"].opt!string)
-			return ver["version"].get!string;
+		// return the last determined version for that commit
+		// not that this is not always correct, most notably when
+		// a tag gets added/removed/changed and changes the outcome
+		// of the full version detection computation
+		auto vcachepath = path ~ ".dub/version.json";
+		if (existsFile(vcachepath)) {
+			auto ver = jsonFromFile(vcachepath);
+			if (head_commit == ver["commit"].opt!string)
+				return ver["version"].get!string;
+		}
 	}
 
 	// if no cache file or the HEAD commit changed, perform full detection
 	auto ret = determineVersionWithGIT(path);
 
-	// update version cache file
-	if (head_commit.length) {
-		if (!existsFile(path ~".dub")) createDirectory(path ~ ".dub");
-		atomicWriteJsonFile(vcachepath, Json(["commit": Json(head_commit), "version": Json(ret)]));
+	version (Windows) {
+		// update version cache file
+		if (head_commit.length) {
+			if (!existsFile(path ~".dub")) createDirectory(path ~ ".dub");
+			atomicWriteJsonFile(vcachepath, Json(["commit": Json(head_commit), "version": Json(ret)]));
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
To speed up the initialization process, this PR adds a file `.dub/version.json` that contains the last known pair of commit hash and version of a particular local GIT working copy. The current commit hash is then determined manually by reading the appropriate files in .git .

Open issues:
 - Can yield wrong results if tags to existing commits get added/changed/removed after the version has been cached
 - Currently doesn't read the "packed-refs" file, so mail fail on some repositories (which just means that it won't be able to hit the fast path)
