### PR TITLE
LDC 0.16.0 removed the -noboundschecks flag, replace with -boundscheck=off

### DIFF
--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -33,7 +33,7 @@ class LdcCompiler : Compiler {
 		//tuple(BuildOption.alwaysStackFrame, ["-?"]),
 		//tuple(BuildOption.stackStomping, ["-?"]),
 		tuple(BuildOption.inline, ["-enable-inlining"]),
-		tuple(BuildOption.noBoundsCheck, ["-disable-boundscheck"]),
+		tuple(BuildOption.noBoundsCheck, ["-boundscheck=off"]),
 		tuple(BuildOption.optimize, ["-O"]),
 		//tuple(BuildOption.profile, ["-?"]),
 		tuple(BuildOption.unittests, ["-unittest"]),


### PR DESCRIPTION
This flag is already existing in 0.15.x so it breaks nothing.