### PR TITLE
A feature like `cargo search`

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1294,11 +1294,17 @@ class SearchCommand : Command {
 			logError("No matches found.");
 			return 1;
 		}
+		auto justify = res
+			.map!((descNmatches) => descNmatches[1])
+			.joiner
+			.map!(m => m.name.length + m.version_.length)
+			.reduce!max + " ()".length;
+		justify += (~justify & 3) + 1; // round to next multiple of 4
 		foreach (desc, matches; res)
 		{
 			logInfo("==== %s ====", desc);
 			foreach (m; matches)
-				logInfo("%s\t%s\t%s", m.name, m.version_, m.description);
+				logInfo("%s%s", leftJustify(m.name ~ " (" ~ m.version_ ~ ")", justify), m.description);
 		}
 		return 0;
 	}

--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -62,6 +62,7 @@ CommandGroup[] getCommands()
 			new AddLocalCommand,
 			new RemoveLocalCommand,
 			new ListCommand,
+			new SearchCommand,
 			new ListInstalledCommand,
 			new AddOverrideCommand,
 			new RemoveOverrideCommand,
@@ -1273,6 +1274,36 @@ class ListInstalledCommand : ListCommand {
 	}
 }
 
+class SearchCommand : Command {
+	this()
+	{
+		this.name = "search";
+		this.argumentsPattern = "<query>";
+		this.description = "Seach for available packages.";
+		this.helpText = [
+			"Search all specified DUB registries for packages matching query."
+		];
+	}
+	override void prepare(scope CommandArgs args) {}
+	override int execute(Dub dub, string[] free_args, string[] app_args)
+	{
+		enforce(free_args.length == 1, "Expected one argument.");
+		auto res = dub.searchPackages(free_args[0]);
+		if (res.empty)
+		{
+			logError("No matches found.");
+			return 1;
+		}
+		foreach (desc, matches; res)
+		{
+			logInfo("==== %s ====", desc);
+			foreach (m; matches)
+				logInfo("%s\t%s\t%s", m.name, m.version_, m.description);
+		}
+		return 0;
+	}
+}
+
 
 /******************************************************************************/
 /* OVERRIDES                                                                  */
@@ -1754,4 +1785,3 @@ private void warnRenamed(string prev, string curr)
 {
 	logWarn("The '%s' Command was renamed to '%s'. Please update your scripts.", prev, curr);
 }
-

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -683,6 +683,12 @@ class Dub {
 		m_packageManager.removeSearchPath(makeAbsolute(path), system ? LocalPackageType.system : LocalPackageType.user);
 	}
 
+	auto searchPackages(string query)
+	{
+		return m_packageSuppliers.map!(ps => tuple(ps.description, ps.searchPackages(query)))
+			.filter!(t => t[1].length);
+	}
+
 	void createEmptyPackage(Path path, string[] deps, string type, PackageFormat format = PackageFormat.sdl)
 	{
 		if (!path.absolute) path = m_rootPath ~ path;

--- a/test/feat663-search.sh
+++ b/test/feat663-search.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+${DUB} search 2>/dev/null && exit 1
+${DUB} search nonexistent123456789package 2>/dev/null && exit 1
+${DUB} search dub | grep -q '^dub' || exit 1


### PR DESCRIPTION
So I've tested the Rust package manager and it has a nice feature to search available packages.

```
$ cargo search gl
Updating registry `https://github.com/rust-lang/crates.io-index`
gfx_gl (0.1.4)           OpenGL bindings for gfx, based on gl-rs
gl_common (0.0.4)        Common glue for libraries using gl-rs
gl_generator (0.0.27)    Syntax extension for creating bindings to the Khronos OpenGL and related APIs
gl (0.0.12)              OpenGL bindings
gfx_device_gl (0.5.0)    OpenGL backend for gfx-rs
glutin (0.3.5)           Cross-plaform OpenGL context provider.
kugel (0.0.2)            Rust-oriented OpenGL wrapper.
khronos_api (0.0.8)      Khronos API XML descriptions for gl_generator
freetypegl (0.1.0)       Rust build helpers and bindings for freetype-gl.
nice_glfw (1.0.1)        Create a modern GL context with glfw
```

It's also nice that it says when its package list cache is updated.