### PR TITLE
Sets MACOSX_DEPLOYMENT_TARGET variable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ echo "module dub.version_;" > source/dub/version_.d
 echo "enum dubVersion = \"$GITVER\";" >> source/dub/version_.d
 
 # For OSX compatibility >= 10.6
-export MACOSX_DEPLOYMENT_TARGET=10.6
+MACOSX_DEPLOYMENT_TARGET=10.6
 
 echo Running $DMD...
 $DMD -ofbin/dub -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,8 @@ GITVER=$(git describe) || GITVER=unknown
 echo "module dub.version_;" > source/dub/version_.d
 echo "enum dubVersion = \"$GITVER\";" >> source/dub/version_.d
 
+# For OSX compatibility >= 10.6
+export MACOSX_DEPLOYMENT_TARGET=10.6
 
 echo Running $DMD...
 $DMD -ofbin/dub -w -version=DubUseCurl -Isource $* $LIBS @build-files.txt


### PR DESCRIPTION
 to avoid trivial incompatibility with OSX version earlier than the one used to build DUB

It avoids the `Illegal instruction` error.

I've tested on OSX 10.6.8 and the next error is:

```
dyld: Library not loaded /usr/lib/libcurl.4.dylib
Referenced from: /path/to/dub
Reason: Incompatible library version: dub requires version 7.0.0 or later, but libcurl.4.dylib provides version 6.0.0
Trace/BPT trap
```