### PR TITLE
Fetch one folder deeper

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -581,6 +581,13 @@ class Dub {
 		if (!placement.existsFile())
 			mkdirRecurse(placement.toNativeString());
 		Path dstpath = placement ~ (packageId ~ "-" ~ clean_package_version);
+		if (!dstpath.existsFile())
+			mkdirRecurse(dstpath.toNativeString());
+
+		// Support libraries typically used with git submodules like ae.
+		// Such libraries need to have ".." as import path but this can create
+		// import path leakage.
+		dstpath = dstpath ~ packageId;
 
 		auto lock = lockFile(dstpath.toNativeString() ~ ".lock", 30.seconds); // possibly wait for other dub instance
 		if (dstpath.existsFile())

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -533,7 +533,16 @@ class PackageManager {
 				try foreach( pdir; iterateDirectory(path) ){
 					logDebug("iterating dir %s entry %s", path.toNativeString(), pdir.name);
 					if( !pdir.isDirectory ) continue;
-					auto pack_path = path ~ (pdir.name ~ "/");
+
+					// Search for a single directory within this directory
+					FileInfo subdir;
+					foreach( pdir2; iterateDirectory(path ~ (pdir.name ~ "/")) )
+					{
+						subdir = pdir2;
+					}
+					if( !subdir.isDirectory ) continue;
+
+					auto pack_path = path ~ (pdir.name ~ "/") ~ (subdir.name ~ "/");
 					auto packageFile = Package.findPackageFile(pack_path);
 					if (packageFile.empty) continue;
 					Package p;

--- a/source/dub/packagemanager.d
+++ b/source/dub/packagemanager.d
@@ -534,11 +534,13 @@ class PackageManager {
 					logDebug("iterating dir %s entry %s", path.toNativeString(), pdir.name);
 					if( !pdir.isDirectory ) continue;
 
-					// Search for a single directory within this directory
+					// Search for a single directory within this directory which happen to be a prefix of pdir
+					// This is to support new folder structure installed over the ancient one.
 					FileInfo subdir;
 					foreach( pdir2; iterateDirectory(path ~ (pdir.name ~ "/")) )
 					{
-						subdir = pdir2;
+						if (pdir.name.startsWith(pdir2.name)) // eg: package vibe-d will be in "vibe-d-x.y.z/vibe-d"
+							subdir = pdir2;
 					}
 					if( !subdir.isDirectory ) continue;
 

--- a/test/issue502-root-import/dub.json
+++ b/test/issue502-root-import/dub.json
@@ -1,0 +1,7 @@
+{
+    "name": "issue502-root-import",
+    "dependencies":
+    {
+        "gitcompatibledubpackage": "~>1.0"
+    }
+}

--- a/test/issue502-root-import/source/app.d
+++ b/test/issue502-root-import/source/app.d
@@ -1,0 +1,10 @@
+import gitcompatibledubpackage.subdir.file;
+
+void main(string[] args)
+{
+}
+
+unittest
+{
+    assert(!hasTheWorldExploded());
+}


### PR DESCRIPTION
This solves #502.

Packages now gets unzipped one directory deeper (eg: `~/.dub/packages/vibe-d-0.7.8/vibe-d/` instead of `/.dub/packages/vibe-d-0.7.8/`).

For scanning, here is how it works now:
- `vibe-d-0.7.8` directory is found by scanning
- (NEW) looking for a mandatory subfolder that is a prefix of `vibe-d-0.7.8`
- and which contains a package description

Once upgrading to the new directory structure, previously listed packages won't be found anymore.
New-style packages get installed over the older ones.
In my tests it works regardless.

What doesn't work is downgrading DUB from the new folder scheme to the older. If downgrading DUB, deleting packages manually is required.