### PR TITLE
[Recipe] Added error messages for SDL malformed dependency name.

### DIFF
--- a/source/dub/recipe/sdl.d
+++ b/source/dub/recipe/sdl.d
@@ -127,6 +127,8 @@ private void parseBuildSetting(Tag setting, ref BuildSettingsTemplate bs, string
 
 private void parseDependency(Tag t, ref BuildSettingsTemplate bs, string package_name)
 {
+	enforceSDL(t.values.length != 0, "Missing dependency name.", t);
+	enforceSDL(t.values.length == 1, "Multiple dependency names.", t);
 	auto pkg = expandPackageName(t.values[0].get!string, package_name, t);
 	enforce(pkg !in bs.dependencies, "The dependency '"~pkg~"' is specified more than once." );
 


### PR DESCRIPTION
Before, 
`dependency version="~>1.2.3"`
caused a range violation.
Now, it says that the dependency name is missing.

The fact that dependencies cannot have multiple names is expressed, as well.

Should there be a correct usage notice here?

P.S. I get the `Failed to parse package description` message twice on either error, how to fix that?