### PR TITLE
fix dmd/ldmd2 detection in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,13 +23,13 @@ if [[ $VERSION < 2.069.0 ]]; then
 fi
 
 # fix for modern GCC versions with --as-needed by default
-if [ "$DMD" = "dmd" ]; then
+if [[ `$DMD --help | head -n1 | grep -P '^DMD(32|64) '` ]]; then
 	if [ `uname` = "Linux" ]; then
 		LIBS="-l:libphobos2.a $LIBS"
 	else
 		LIBS="-lphobos2 $LIBS"
 	fi
-elif [ "$DMD" = "ldmd2" ]; then
+elif [[ `$DMD --help | head -n1 | grep -P '^LDC '` ]]; then
 	LIBS="-lphobos2-ldc $LIBS"
 fi
 


### PR DESCRIPTION
Supposed to work with dlang.org's [peculiar way of setting DMD/DC](https://github.com/D-Programming-Language/dlang.org/blob/35bd01726086d434db470fe916e3122e90a2f257/posix.mak#L488).