### PR TITLE
Make sublimetext generator create import paths for DKit

### DIFF
--- a/source/dub/generators/sublimetext.d
+++ b/source/dub/generators/sublimetext.d
@@ -38,6 +38,7 @@ class SublimeTextGenerator : ProjectGenerator {
 		auto root = Json([
 			"folders": targets.byValue.map!targetFolderJson.array.Json,
 			"build_systems": buildSystems(settings.platform),
+			"settings": [ "include_paths": buildSettings.importPaths.map!Json.array.Json ].Json,
 		]);
 
 		auto jsonString = appender!string();


### PR DESCRIPTION
Simplifies project setup by setting include_paths for [DKit](https://github.com/yazd/DKit/) and therefore [DCD](https://github.com/Hackerpilot/DCD).