### PR TITLE
Fix "dub dustmite" for path based dependencies. Fixes #240.

### DIFF
--- a/source/dub/commandline.d
+++ b/source/dub/commandline.d
@@ -1602,13 +1602,15 @@ class DustmiteCommand : PackageBuildCommand {
 				copyFolderRec(pack.path, dst_path);
 
 				// overwrite package description file with additional version information
-				pack_.storeInfo(dst_path);
+				pack.storeInfo(dst_path);
 			}
 
 			// adjust all path based dependencies of the root package
 			void fixPathDependency(string pack, ref Dependency dep) {
-				if (dep.path.length > 0)
-					dep.path = Path("../") ~ pack;
+				if (dep.path.length > 0) {
+					auto mainpack = getBasePackageName(pack);
+					dep.path = Path("../") ~ mainpack;
+				}
 			}
 			foreach (name, ref dep; prj.rootPackage.info.buildSettings.dependencies)
 				fixPathDependency(name, dep);

--- a/source/dub/project.d
+++ b/source/dub/project.d
@@ -115,6 +115,12 @@ class Project {
 
 	/** Allows iteration of the dependency tree in topological order
 	*/
+	int delegate(int delegate(ref Package)) getTopologicalPackageList(bool children_first = false, Package root_package = null, string[string] configs = null)
+	{
+		// ugly way to avoid code duplication since inout isn't compatible with foreach type inference
+		return cast(int delegate(int delegate(ref Package)))(cast(const)this).getTopologicalPackageList(children_first, root_package, configs);
+	}
+	/// ditto
 	int delegate(int delegate(ref const Package)) getTopologicalPackageList(bool children_first = false, in Package root_package = null, string[string] configs = null)
 	const {
 		const(Package) rootpack = root_package ? root_package : m_rootPackage;


### PR DESCRIPTION
This adds handling of path based dependencies to sub packages, as well as path based dependencies of dependencies. Previously, only path based dependencies of the root package god adjusted.