### PR TITLE
Let dub.selections.json always have precedence. Fixes #754.

### DIFF
--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -290,7 +290,8 @@ class Dub {
 			return;
 		}
 
-		foreach (p, ver; versions) {
+		foreach (p; versions.byKey) {
+			auto ver = versions[p]; // Workaround for DMD 2.070.0 AA issue (crashes in aaApply2 if iterating by key+value)
 			assert(!p.canFind(":"), "Resolved packages contain a sub package!?: "~p);
 			Package pack;
 			if (!ver.path.empty) {

--- a/source/dub/dub.d
+++ b/source/dub/dub.d
@@ -227,7 +227,9 @@ class Dub {
 			foreach (p; m_project.selections.selectedPackages) {
 				auto dep = m_project.selections.getSelectedVersion(p);
 				if (!dep.path.empty) {
-					try if (m_packageManager.getOrLoadPackage(dep.path)) continue;
+					auto path = dep.path;
+					if (!path.absolute) path = this.rootPath ~ path;
+					try if (m_packageManager.getOrLoadPackage(path)) continue;
 					catch (Exception e) { logDebug("Failed to load path based selection: %s", e.toString().sanitize); }
 				} else {
 					if (m_packageManager.getPackage(p, dep.version_)) continue;

--- a/test/issue754-path-selection-fail/a-1.0/dub.sdl
+++ b/test/issue754-path-selection-fail/a-1.0/dub.sdl
@@ -1,0 +1,2 @@
+name "a"
+version "1.0.0"

--- a/test/issue754-path-selection-fail/a-1.0/source/a.d
+++ b/test/issue754-path-selection-fail/a-1.0/source/a.d
@@ -1,0 +1,3 @@
+module a;
+
+void test() {}

--- a/test/issue754-path-selection-fail/a-2.0/dub.sdl
+++ b/test/issue754-path-selection-fail/a-2.0/dub.sdl
@@ -1,0 +1,3 @@
+name "a"
+version "2.0.0"
+

--- a/test/issue754-path-selection-fail/dub.sdl
+++ b/test/issue754-path-selection-fail/dub.sdl
@@ -1,0 +1,2 @@
+name "test"
+dependency "a" path="a-2.0"

--- a/test/issue754-path-selection-fail/dub.selections.json
+++ b/test/issue754-path-selection-fail/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"a": {"path": "a-1.0"}
+	}
+}

--- a/test/issue754-path-selection-fail/source/app.d
+++ b/test/issue754-path-selection-fail/source/app.d
@@ -1,0 +1,6 @@
+import a;
+
+void main()
+{
+	test();
+}


### PR DESCRIPTION
Path based dependencies in dub.sdl/json used to have precedence over dub.selections.json, leading to the error message in #754.