### PR TITLE
Fix the error regex in the Sublime Text generator

### DIFF
--- a/source/dub/generators/sublimetext.d
+++ b/source/dub/generators/sublimetext.d
@@ -80,6 +80,13 @@ Json buildSystems(BuildPlatform buildPlatform, string workingDiretory = getcwd()
 		"unittest-cov",
 		];
 
+	string fileRegex;
+
+	if (buildPlatform.frontendVersion >= 2066 && buildPlatform.compiler == "dmd")
+		fileRegex = r"^(.+)\(([0-9]+)\,([0-9]+)\)\:() (.*)$";
+	else
+		fileRegex = r"^(.+)\(([0-9]+)\)\:() (.*)$";
+
 	auto arch = buildPlatform.architecture[0];
 
 	Json makeBuildSystem(string buildType)
@@ -87,7 +94,7 @@ Json buildSystems(BuildPlatform buildPlatform, string workingDiretory = getcwd()
 		return Json([
 			"name": "DUB build " ~ buildType.Json,
 			"cmd": ["dub", "build", "--build=" ~ buildType, "--arch=" ~ arch].map!Json.array.Json,
-			"file_regex": r"^(.+)\(([0-9]+)\)\:() (.*)$".Json,
+			"file_regex": fileRegex.Json,
 			"working_dir": workingDiretory.Json,
 			"variants": [
 				[


### PR DESCRIPTION
Code for the DMD compiler always adds -vcollumns flag if the frontend
version is >= 2066. The old regex assumes that the error message has
only a line number. This change fixes the generator so that it enables
error navigation for this specific compiler setup.