### PR TITLE
Quick fix for shared libraries with (LDC || OSX)

### DIFF
--- a/source/dub/compilers/dmd.d
+++ b/source/dub/compilers/dmd.d
@@ -176,6 +176,7 @@ class DmdCompiler : Compiler {
 				break;
 			case TargetType.dynamicLibrary:
 				version (Windows) settings.addDFlags("-shared");
+				else version (OSX) settings.addDFlags("-shared");
 				else settings.addDFlags("-shared", "-defaultlib=libphobos2.so");
 				break;
 			case TargetType.object:

--- a/source/dub/compilers/ldc.d
+++ b/source/dub/compilers/ldc.d
@@ -162,7 +162,9 @@ class LdcCompiler : Compiler {
 				settings.addDFlags("-lib");
 				break;
 			case TargetType.dynamicLibrary:
-				settings.addDFlags("-shared", "-defaultlib=phobos2");
+				version(Windows) settings.addDFlags("-shared");
+				else version(OSX) settings.addDFlags("-shared");
+				else settings.addDFlags("-shared", "-defaultlib=phobos2");
 				break;
 			case TargetType.object:
 				settings.addDFlags("-c");


### PR DESCRIPTION
This is a quick fix for #647.

It supersedes PR https://github.com/D-Programming-Language/dub/pull/681 which still has an interesting discussion.